### PR TITLE
Fix disabling of next/previous buttons

### DIFF
--- a/addon/components/pagination-pager.js
+++ b/addon/components/pagination-pager.js
@@ -52,11 +52,11 @@ export default Ember.Component.extend({
   }),
 
   isFirst: computed('firstPage', 'current', function () {
-    return this.get('current') === this.get('firstPage');
+    return this.get('currentPage') === this.get('firstPage');
   }),
 
   isLast: computed('lastPage', 'current', function () {
-    return this.get('current') === this.get('lastPage');
+    return this.get('currentPage') === this.get('lastPage');
   }),
 
   isHidden: computed('hide', 'count', function () {


### PR DESCRIPTION
Fix condition for first/last page, which allows those buttons to be disabled when you're on the first or last page.