### PR TITLE
be more Glimmer-friendly

### DIFF
--- a/addon/components/page-item.js
+++ b/addon/components/page-item.js
@@ -6,6 +6,7 @@ export default Ember.Component.extend({
   tagName: 'li',
   classNameBindings: ['isActive:active'],
   seperator: '…',
+  selected: null,
 
   url: computed('urlTemplate', 'page', function () {
     var urlTemplate = this.get('urlTemplate');
@@ -28,12 +29,11 @@ export default Ember.Component.extend({
   }),
 
   actions: {
-    setCurrent: function () {
+    select: function () {
       var last = this.get('selected');
       var page = this.get('page');
 
       if (page !== last) {
-        this.set('selected', page);
         this.sendAction('pageSet', page, last);
       }
     }

--- a/addon/components/pagination-pager.js
+++ b/addon/components/pagination-pager.js
@@ -137,7 +137,6 @@ export default Ember.Component.extend({
         var previous = parseInt(this.get('current'), 10);
         var current = previous + 1;
 
-        this.set('current', current);
         this.send('pageChanged', current, previous);
       }
     },
@@ -147,12 +146,12 @@ export default Ember.Component.extend({
         var previous = parseInt(this.get('current'), 10);
         var current = previous - 1;
 
-        this.set('current', current);
         this.send('pageChanged', current, previous);
       }
     },
 
     pageChanged: function (page, previous) {
+      this.set('current', page);
       this.sendAction('change', page, previous);
     }
   }

--- a/app/templates/components/page-item.hbs
+++ b/app/templates/components/page-item.hbs
@@ -1,5 +1,5 @@
 {{#if isDots}}
   <a>{{page}}</a>
 {{else}}
-  <a href="{{url}}" {{action 'setCurrent'}}>{{page}}</a>
+  <a href="{{url}}" {{action 'select'}}>{{page}}</a>
 {{/if}}

--- a/app/templates/components/pagination-pager.hbs
+++ b/app/templates/components/pagination-pager.hbs
@@ -4,7 +4,7 @@
   </li>
 
   {{#each pages as |page|}}
-    {{page-item page=page selected=current seperator=seperator urlTemplate=urlTemplate pageSet='pageChanged'}}
+    {{page-item page=page selected=this.current seperator=seperator urlTemplate=urlTemplate pageSet='pageChanged'}}
   {{/each}}
 
   <li class="next {{if isLast 'disabled'}}">


### PR DESCRIPTION
page-item was setting `current` and expecting that to bubble up to `pagination-pager`. In Glimmer, that's a no-no; data flows down, actions up.

Instead, we simply trigger the change event and let the parent `pagination-pager` component respond and change the data.

This also changes `page-item`'s action from `setSelected` to `select` to reflect that it's not *setting* anything directly.