### PR TITLE
fix Duplicate key error for ember 1.13

### DIFF
--- a/app/templates/components/pagination-pager.hbs
+++ b/app/templates/components/pagination-pager.hbs
@@ -3,7 +3,7 @@
     <a href="{{previousUrl}}" {{action 'previous'}}>{{paginationPrevious}}</a>
   </li>
 
-  {{#each pages as |page|}}
+  {{#each pages key="@index" as |page|}}
     {{page-item page=page selected=this.current seperator=seperator urlTemplate=urlTemplate pageSet='pageChanged'}}
   {{/each}}
 


### PR DESCRIPTION
Uncaught Error: Duplicate key found ('…') for '{{each}}' helper, please use a unique key or switch to '{{#each model key=@index}}{{/each}}