### PR TITLE
Fixes deprecation warning in ember-cli 2.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
   },
   "author": "Ilya Radchenko <ilya@burstcreations.com>",
   "license": "MIT",
+  "dependencies": {
+    "ember-cli-babel": "^5.1.7"
+  },
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.2",
     "broccoli-merge-trees": "^0.2.4",


### PR DESCRIPTION
```
DEPRECATION: Addon files were detected in `/Users/jpadilla/Projects/Alias/gasolinamovil/admin/node_modules/pagination-pager/addon`, but no JavaScript preprocessors were found for `pagination-pager`. Please make sure to add a preprocessor (most likely `ember-cli-babel`) to in `dependencies` (NOT `devDependencies`) in `pagination-pager`'s `package.json`.
```