### PR TITLE
[FEATURE] Adds baseUrlTemplate option

### DIFF
--- a/addon/components/page-item.js
+++ b/addon/components/page-item.js
@@ -11,6 +11,11 @@ export default Ember.Component.extend({
   url: computed('urlTemplate', 'page', function () {
     var urlTemplate = this.get('urlTemplate');
     var current = this.get('page');
+    var baseUrlTemplate = this.get('baseUrlTemplate');
+
+    if(baseUrlTemplate && (current === 1)){
+      return baseUrlTemplate;
+    }
 
     urlTemplate = urlTemplate.replace('{current}', current);
 

--- a/addon/components/page-item.js
+++ b/addon/components/page-item.js
@@ -11,9 +11,10 @@ export default Ember.Component.extend({
   url: computed('urlTemplate', 'page', function () {
     var urlTemplate = this.get('urlTemplate');
     var current = this.get('page');
+    var firstPage = this.get('firstPage');
     var firstPageUrlTemplate = this.get('firstPageUrlTemplate');
 
-    if(firstPageUrlTemplate && (current === 1)){
+    if(firstPageUrlTemplate && (current === firstPage)){
       return firstPageUrlTemplate;
     }
 

--- a/addon/components/page-item.js
+++ b/addon/components/page-item.js
@@ -11,10 +11,10 @@ export default Ember.Component.extend({
   url: computed('urlTemplate', 'page', function () {
     var urlTemplate = this.get('urlTemplate');
     var current = this.get('page');
-    var baseUrlTemplate = this.get('baseUrlTemplate');
+    var firstPageUrlTemplate = this.get('firstPageUrlTemplate');
 
-    if(baseUrlTemplate && (current === 1)){
-      return baseUrlTemplate;
+    if(firstPageUrlTemplate && (current === 1)){
+      return firstPageUrlTemplate;
     }
 
     urlTemplate = urlTemplate.replace('{current}', current);

--- a/addon/components/pagination-pager.js
+++ b/addon/components/pagination-pager.js
@@ -52,6 +52,11 @@ export default Ember.Component.extend({
   firstUrl: computed('urlTemplate', 'current', 'firstPage', function () {
     var urlTemplate = this.get('urlTemplate');
     var firstPage = this.get('firstPage');
+    var firstPageUrlTemplate = this.get('firstPageUrlTemplate');
+
+    if(firstPageUrlTemplate) {
+      return firstPageUrlTemplate;
+    }
 
     urlTemplate = urlTemplate.replace('{current}', firstPage);
 

--- a/addon/components/pagination-pager.js
+++ b/addon/components/pagination-pager.js
@@ -21,17 +21,17 @@ export default Ember.Component.extend({
   firstPage: 1,
   current: 1,
   urlTemplate: '#',
-  baseUrlTemplate: null,
+  firstPageUrlTemplate: null,
   lastPage: alias('count'),
 
   previousUrl: computed('urlTemplate', 'current', 'firstPage', function () {
     var urlTemplate = this.get('urlTemplate');
     var current = this.get('current');
     var firstPage = this.get('firstPage');
-    var baseUrlTemplate = this.get('baseUrlTemplate');
+    var firstPageUrlTemplate = this.get('firstPageUrlTemplate');
 
-    if(baseUrlTemplate && (((current - 1) === firstPage) || current === firstPage)) {
-      return baseUrlTemplate;
+    if(firstPageUrlTemplate && (((current - 1) === firstPage) || current === firstPage)) {
+      return firstPageUrlTemplate;
     }
 
     urlTemplate = urlTemplate.replace('{current}', current > firstPage ? current - 1 : current);

--- a/addon/components/pagination-pager.js
+++ b/addon/components/pagination-pager.js
@@ -21,6 +21,7 @@ export default Ember.Component.extend({
   firstPage: 1,
   current: 1,
   urlTemplate: '#',
+  baseUrlTemplate: null,
   lastPage: alias('count'),
 
   previousUrl: computed('urlTemplate', 'current', 'firstPage', function () {

--- a/addon/components/pagination-pager.js
+++ b/addon/components/pagination-pager.js
@@ -28,6 +28,11 @@ export default Ember.Component.extend({
     var urlTemplate = this.get('urlTemplate');
     var current = this.get('current');
     var firstPage = this.get('firstPage');
+    var baseUrlTemplate = this.get('baseUrlTemplate');
+
+    if(baseUrlTemplate && (((current - 1) === firstPage) || current === firstPage)) {
+      return baseUrlTemplate;
+    }
 
     urlTemplate = urlTemplate.replace('{current}', current > firstPage ? current - 1 : current);
 

--- a/app/templates/components/pagination-pager.hbs
+++ b/app/templates/components/pagination-pager.hbs
@@ -11,7 +11,7 @@
         selected=this.current
         seperator=seperator
         urlTemplate=urlTemplate
-        baseUrlTemplate=baseUrlTemplate
+        firstPageUrlTemplate=firstPageUrlTemplate
         pageSet='pageChanged'
       }}
     {{/each}}

--- a/app/templates/components/pagination-pager.hbs
+++ b/app/templates/components/pagination-pager.hbs
@@ -5,7 +5,15 @@
     </li>
 
     {{#each pages key="@index" as |page|}}
-      {{page-item disabled=disabled page=page selected=this.current seperator=seperator urlTemplate=urlTemplate pageSet='pageChanged'}}
+      {{page-item
+        disabled=disabled
+        page=page
+        selected=this.current
+        seperator=seperator
+        urlTemplate=urlTemplate
+        baseUrlTemplate=baseUrlTemplate
+        pageSet='pageChanged'
+      }}
     {{/each}}
 
     <li class="next {{if isLastDisabled 'disabled'}}">

--- a/app/templates/components/pagination-pager.hbs
+++ b/app/templates/components/pagination-pager.hbs
@@ -11,6 +11,7 @@
         selected=this.current
         seperator=seperator
         urlTemplate=urlTemplate
+        firstPage=firstPage
         firstPageUrlTemplate=firstPageUrlTemplate
         pageSet='pageChanged'
       }}


### PR DESCRIPTION
Adds a `baseUrlTemplate` option to the component, which allows to use an alternative url template for page 1. I.e. a nothing `/`, instead of `?page=1`, like:

```
{{pagination-pager
  count=(readonly totalPages)
  current=(readonly page)
  urlTemplate=(concat "/search/" someTerms "/page-{current}")
  baseUrlTemplate=(concat "/search/" someTerms)
  change=(action 'setPage')
}}
```